### PR TITLE
Notification: Update switch state on preference display

### DIFF
--- a/src/com/android/settings/notification/AssistantCapabilityPreferenceController.java
+++ b/src/com/android/settings/notification/AssistantCapabilityPreferenceController.java
@@ -22,6 +22,8 @@ import android.service.notification.Adjustment;
 import com.android.settings.core.TogglePreferenceController;
 
 import com.google.common.annotations.VisibleForTesting;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
 
 import java.util.List;
 
@@ -34,6 +36,15 @@ public class AssistantCapabilityPreferenceController extends TogglePreferenceCon
     public AssistantCapabilityPreferenceController(Context context, String key) {
         super(context, key);
         mBackend = new NotificationBackend();
+    }
+
+    @Override
+    public void displayPreference(PreferenceScreen screen) {
+        super.displayPreference(screen);
+        Preference preference = screen.findPreference(getPreferenceKey());
+        if (preference != null) {
+            updateState(preference);
+        }
     }
 
     @VisibleForTesting

--- a/src/com/android/settings/notification/BadgingNotificationPreferenceController.java
+++ b/src/com/android/settings/notification/BadgingNotificationPreferenceController.java
@@ -57,6 +57,7 @@ public class BadgingNotificationPreferenceController extends TogglePreferenceCon
         super.displayPreference(screen);
         Preference preference = screen.findPreference(NOTIFICATION_BADGING);
         if (preference != null) {
+            updateState(preference);
             mSettingObserver = new SettingObserver(preference);
         }
     }

--- a/src/com/android/settings/notification/NotificationRingtonePreferenceController.java
+++ b/src/com/android/settings/notification/NotificationRingtonePreferenceController.java
@@ -19,6 +19,9 @@ package com.android.settings.notification;
 import android.content.Context;
 import android.media.RingtoneManager;
 
+import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
+
 import com.android.settings.R;
 
 public class NotificationRingtonePreferenceController extends RingtonePreferenceControllerBase {
@@ -27,6 +30,15 @@ public class NotificationRingtonePreferenceController extends RingtonePreference
 
     public NotificationRingtonePreferenceController(Context context) {
         super(context);
+    }
+
+    @Override
+    public void displayPreference(PreferenceScreen screen) {
+        super.displayPreference(screen);
+        Preference preference = screen.findPreference(getPreferenceKey());
+        if (preference != null) {
+            updateState(preference);
+        }
     }
 
     @Override

--- a/src/com/android/settings/notification/SnoozeNotificationPreferenceController.java
+++ b/src/com/android/settings/notification/SnoozeNotificationPreferenceController.java
@@ -24,6 +24,8 @@ import android.provider.Settings;
 import com.android.settings.core.TogglePreferenceController;
 
 import androidx.annotation.VisibleForTesting;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
 
 public class SnoozeNotificationPreferenceController extends TogglePreferenceController {
 
@@ -35,6 +37,15 @@ public class SnoozeNotificationPreferenceController extends TogglePreferenceCont
 
     public SnoozeNotificationPreferenceController(Context context, String preferenceKey) {
         super(context, preferenceKey);
+    }
+
+    @Override
+    public void displayPreference(PreferenceScreen screen) {
+        super.displayPreference(screen);
+        Preference preference = screen.findPreference(getPreferenceKey());
+        if (preference != null) {
+            updateState(preference);
+        }
     }
 
     @Override

--- a/src/com/android/settings/notification/ZenModePreferenceController.java
+++ b/src/com/android/settings/notification/ZenModePreferenceController.java
@@ -46,7 +46,11 @@ public class ZenModePreferenceController extends BasePreferenceController
     @Override
     public void displayPreference(PreferenceScreen screen) {
         super.displayPreference(screen);
-        mSettingObserver = new SettingObserver(screen.findPreference(getPreferenceKey()));
+        Preference preference = screen.findPreference(getPreferenceKey());
+        if (preference != null) {
+            updateState(preference);
+            mSettingObserver = new SettingObserver(preference);
+        }
     }
 
     @Override


### PR DESCRIPTION
When expanding advanced notification settings preference states not getting updated.
To fix this issue update states on preference display.