### PR TITLE
Phone ringtone setting for Multi SIM device

### DIFF
--- a/res/xml/sound_settings.xml
+++ b/res/xml/sound_settings.xml
@@ -157,6 +157,15 @@
         android:order="-100"
         settings:keywords="@string/sound_settings"/>
 
+    <!-- Phone ringtone for SIM2 -->
+    <com.android.settings.DefaultRingtonePreference
+        android:key="ringtone2"
+        android:title="@string/ringtone_title"
+        android:dialogTitle="@string/ringtone_title"
+        android:summary="@string/summary_placeholder"
+        android:ringtoneType="ringtone"
+        android:order="-90"/>
+        
     <!-- Default notification ringtone -->
     <com.android.settings.DefaultRingtonePreference
         android:key="notification_ringtone"
@@ -164,7 +173,7 @@
         android:dialogTitle="@string/notification_ringtone_title"
         android:summary="@string/summary_placeholder"
         android:ringtoneType="notification"
-        android:order="-90"/>
+        android:order="-80"/>
 
     <!-- Default alarm ringtone -->
     <com.android.settings.DefaultRingtonePreference
@@ -174,7 +183,7 @@
         android:summary="@string/summary_placeholder"
         android:persistent="false"
         android:ringtoneType="alarm"
-        android:order="-80"/>
+        android:order="-70"/>
 
     <!-- Other sounds -->
     <PreferenceCategory

--- a/src/com/android/settings/DefaultRingtonePreference.java
+++ b/src/com/android/settings/DefaultRingtonePreference.java
@@ -43,12 +43,14 @@ public class DefaultRingtonePreference extends RingtonePreference {
 
     @Override
     protected void onSaveRingtone(Uri ringtoneUri) {
-        RingtoneManager.setActualDefaultRingtoneUri(mUserContext, getRingtoneType(), ringtoneUri);
+        RingtoneManager.setActualDefaultRingtoneUriForPhoneAccountHandle(mUserContext,
+                getRingtoneType(), ringtoneUri, getPhoneAccountHandle());
     }
 
     @Override
     protected Uri onRestoreRingtone() {
-        return RingtoneManager.getActualDefaultRingtoneUri(mUserContext, getRingtoneType());
+        return RingtoneManager.getActualDefaultRingtoneUriForPhoneAccountHandle(mUserContext,
+                getRingtoneType(), getPhoneAccountHandle());
     }
 
 }

--- a/src/com/android/settings/RingtonePreference.java
+++ b/src/com/android/settings/RingtonePreference.java
@@ -24,6 +24,7 @@ import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.UserHandle;
 import android.provider.Settings.System;
+import android.telecom.PhoneAccountHandle;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 
@@ -54,6 +55,7 @@ public class RingtonePreference extends Preference {
     private int mRingtoneType;
     private boolean mShowDefault;
     private boolean mShowSilent;
+    private PhoneAccountHandle mPhoneAccountHandle;
 
     private int mRequestCode;
     protected int mUserId;
@@ -84,6 +86,25 @@ public class RingtonePreference extends Preference {
         return mUserId;
     }
 
+    /**
+     * Sets the {@link PhoneAccountHandle} that this preference belongs to.
+     *
+     * @param phoneAccountHandle The {@link PhoneAccountHandle} that this preference belongs to.
+     */
+    public void setPhoneAccountHandle(PhoneAccountHandle phoneAccountHandle) {
+        mPhoneAccountHandle = phoneAccountHandle;
+    }
+
+    /**
+     * Returns the {@link PhoneAccountHandle} that this preference belongs to.
+     *
+     * @return The {@link PhoneAccountHandle} that this preference belongs to.
+     * @see #setPhoneAccountHandle(PhoneAccountHandle)
+     */
+    public PhoneAccountHandle getPhoneAccountHandle() {
+        return mPhoneAccountHandle;
+    }
+    
     /**
      * Returns the sound type(s) that are shown in the picker.
      *

--- a/src/com/android/settings/notification/PhoneRingtone2PreferenceController.java
+++ b/src/com/android/settings/notification/PhoneRingtone2PreferenceController.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.notification;
+
+import android.content.Context;
+
+import com.android.settings.Utils;
+
+public class PhoneRingtone2PreferenceController extends PhoneRingtonePreferenceController {
+
+    private static final String KEY_PHONE_RINGTONE2 = "ringtone2";
+    private static final int PHONE_RINGTONE_PREFERENCE_ID = 1;
+
+    public PhoneRingtone2PreferenceController(Context context) {
+        super(context);
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return KEY_PHONE_RINGTONE2;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return Utils.isVoiceCapable(mContext) && hasMultiPhoneAccountHandle();
+    }
+
+    @Override
+    public int getIdForPhoneRingtonePreference() {
+        return PHONE_RINGTONE_PREFERENCE_ID;
+    }
+}

--- a/src/com/android/settings/notification/PhoneRingtonePreferenceController.java
+++ b/src/com/android/settings/notification/PhoneRingtonePreferenceController.java
@@ -19,14 +19,54 @@ package com.android.settings.notification;
 import android.content.Context;
 import android.media.RingtoneManager;
 
+import android.telecom.PhoneAccount;
+import android.telecom.PhoneAccountHandle;
+import android.telecom.TelecomManager;
+import android.telephony.SubscriptionInfo;
+import android.telephony.SubscriptionManager;
+import android.telephony.TelephonyManager;
+
+import androidx.preference.PreferenceScreen;
+
+import com.android.settings.DefaultRingtonePreference;
+import com.android.settings.R;
 import com.android.settings.Utils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class PhoneRingtonePreferenceController extends RingtonePreferenceControllerBase {
 
     private static final String KEY_PHONE_RINGTONE = "phone_ringtone";
+    private static final String EMERGENCY_PHONE_ACCOUNT_HANDLE_ID = "E";
+    private static final String RINGTONE_DELIMITER_FOR_PHONE_ACCOUNT_HANDLE = " - ";
+    private static final int PHONE_RINGTONE_PREFERENCE_ID = 0;
 
+    private TelecomManager mTelecomManager;
+    
     public PhoneRingtonePreferenceController(Context context) {
         super(context);
+        mTelecomManager = (TelecomManager) mContext.getSystemService(Context.TELECOM_SERVICE);
+    }
+
+    @Override
+    public void displayPreference(PreferenceScreen screen) {
+        super.displayPreference(screen);
+
+        DefaultRingtonePreference ringtonePreference =
+                (DefaultRingtonePreference) screen.findPreference(getPreferenceKey());
+        PhoneAccountHandle phoneAccountHandle = getCurrentPhoneAccountHandle();
+        ringtonePreference.setPhoneAccountHandle(phoneAccountHandle);
+
+        if (hasMultiPhoneAccountHandle()) {
+            // For multi PhoneAccountHandle case, will show multi ringtone setting.
+            // So shoud show "Phone ringtone - operator name" for each ringtone setting.
+            CharSequence displayName = getDisplayNameForRingtonePreference(phoneAccountHandle);
+            if (displayName != null) {
+                ringtonePreference.setTitle(mContext.getString(R.string.ringtone_title)
+                        + RINGTONE_DELIMITER_FOR_PHONE_ACCOUNT_HANDLE + displayName);
+            }
+        }
     }
 
     @Override
@@ -42,5 +82,52 @@ public class PhoneRingtonePreferenceController extends RingtonePreferenceControl
     @Override
     public int getRingtoneType() {
         return RingtoneManager.TYPE_RINGTONE;
+    }
+
+    public int getIdForPhoneRingtonePreference() {
+        return PHONE_RINGTONE_PREFERENCE_ID;
+    }
+
+    public boolean hasMultiPhoneAccountHandle() {
+        return getPhoneAccountHandles().size() > 1;
+    }
+
+    private PhoneAccountHandle getCurrentPhoneAccountHandle() {
+        List<PhoneAccountHandle> accountHandles = getPhoneAccountHandles();
+        int id = getIdForPhoneRingtonePreference();
+        if (accountHandles != null && accountHandles.size() > id) {
+            return accountHandles.get(id);
+        }
+        return null;
+    }
+
+    // This method is to get the available phone account handles of the SIMs.
+    private List<PhoneAccountHandle> getPhoneAccountHandles() {
+        List<PhoneAccountHandle> subscriptionAccountHandles = new ArrayList<>();
+        List<PhoneAccountHandle> accountHandles = mTelecomManager.getCallCapablePhoneAccounts(true);
+        for (PhoneAccountHandle accountHandle : accountHandles) {
+            PhoneAccount phoneAccount = mTelecomManager.getPhoneAccount(accountHandle);
+            // Emergency phone account also has CAPABILITY_SIM_SUBSCRIPTION, so should exclude it.
+            if (phoneAccount.hasCapabilities(PhoneAccount.CAPABILITY_SIM_SUBSCRIPTION)
+                    && !EMERGENCY_PHONE_ACCOUNT_HANDLE_ID.equals(accountHandle.getId())) {
+                subscriptionAccountHandles.add(accountHandle);
+            }
+        }
+        return subscriptionAccountHandles;
+    }
+
+    private CharSequence getDisplayNameForRingtonePreference(
+                PhoneAccountHandle phoneAccountHandle) {
+        TelephonyManager telephonyManager = (TelephonyManager) mContext
+                .getSystemService(Context.TELEPHONY_SERVICE);
+        SubscriptionManager subscriptionManager = (SubscriptionManager) mContext
+                .getSystemService(Context.TELEPHONY_SUBSCRIPTION_SERVICE);
+        PhoneAccount phoneAccount = mTelecomManager.getPhoneAccount(phoneAccountHandle);
+        int subId = telephonyManager.getSubIdForPhoneAccount(phoneAccount);
+        SubscriptionInfo subInfo = subscriptionManager.getActiveSubscriptionInfo(subId);
+        if (subInfo != null) {
+            return subInfo.getDisplayName();
+        }
+        return null;
     }
 }

--- a/src/com/android/settings/notification/RingtonePreferenceControllerBase.java
+++ b/src/com/android/settings/notification/RingtonePreferenceControllerBase.java
@@ -24,6 +24,7 @@ import android.util.Log;
 
 import androidx.preference.Preference;
 
+import com.android.settings.RingtonePreference;
 import com.android.settings.core.PreferenceControllerMixin;
 import com.android.settingslib.core.AbstractPreferenceController;
 import com.android.settingslib.utils.ThreadUtils;
@@ -51,9 +52,9 @@ public abstract class RingtonePreferenceControllerBase extends AbstractPreferenc
     }
 
     private void updateSummary(Preference preference) {
-        final Uri ringtoneUri = RingtoneManager.getActualDefaultRingtoneUri(
-                mContext, getRingtoneType());
-
+        final Uri ringtoneUri = RingtoneManager.getActualDefaultRingtoneUriForPhoneAccountHandle(
+                mContext, getRingtoneType(),
+                        ((RingtonePreference)preference).getPhoneAccountHandle());
         final CharSequence summary;
         try {
             summary = Ringtone.getTitle(

--- a/src/com/android/settings/notification/SoundSettings.java
+++ b/src/com/android/settings/notification/SoundSettings.java
@@ -267,6 +267,7 @@ public class SoundSettings extends DashboardFragment implements OnActivityResult
 
         // === Phone & notification ringtone ===
         controllers.add(new PhoneRingtonePreferenceController(context));
+        controllers.add(new PhoneRingtone2PreferenceController(context));
         controllers.add(new AlarmRingtonePreferenceController(context));
         controllers.add(new NotificationRingtonePreferenceController(context));
         controllers.add(new IncreasingRingPreferenceController(context));

--- a/tests/robotests/src/com/android/settings/notification/PhoneRingtone2PreferenceControllerTest.java
+++ b/tests/robotests/src/com/android/settings/notification/PhoneRingtone2PreferenceControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 The Android Open Source Project
+ * Copyright (C) 2019 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ import org.robolectric.shadows.ShadowApplication;
 import static org.mockito.ArgumentMatchers.anyInt;
 
 @RunWith(RobolectricTestRunner.class)
-public class PhoneRingtonePreferenceControllerTest {
+public class PhoneRingtone2PreferenceControllerTest {
 
     @Mock
     private TelephonyManager mTelephonyManager;
@@ -65,9 +65,9 @@ public class PhoneRingtonePreferenceControllerTest {
     private PreferenceScreen mPreferenceScreen;
     @Mock
     private DefaultRingtonePreference mPreference;
-    
+
     private Context mContext;
-    private PhoneRingtonePreferenceController mController;
+    private PhoneRingtone2PreferenceController mController;
 
     private static final PhoneAccountHandle PHONE_ACCOUNT_HANDLE_1 = new PhoneAccountHandle(
             new ComponentName("pkg", "cls"), "id_1", UserHandle.of(0));
@@ -84,7 +84,7 @@ public class PhoneRingtonePreferenceControllerTest {
                     .build();
 
     private static final String PHONE_ACCOUNT_HANDLE_DISPLAY_NAME = "TEST";
-    
+
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
@@ -94,7 +94,7 @@ public class PhoneRingtonePreferenceControllerTest {
         shadowContext.setSystemService(Context.TELEPHONY_SUBSCRIPTION_SERVICE,
                 mSubscriptionManager);
         mContext = RuntimeEnvironment.application;
-        mController = new PhoneRingtonePreferenceController(mContext);
+        mController = new PhoneRingtone2PreferenceController(mContext);
     }
 
     @Test
@@ -102,12 +102,14 @@ public class PhoneRingtonePreferenceControllerTest {
         when(mPreferenceScreen.findPreference(mController.getPreferenceKey()))
                 .thenReturn(mPreference);
         when(mTelecomManager.getCallCapablePhoneAccounts(true))
-                .thenReturn(Arrays.asList(PHONE_ACCOUNT_HANDLE_1));
+                .thenReturn(Arrays.asList(PHONE_ACCOUNT_HANDLE_1, PHONE_ACCOUNT_HANDLE_2));
         when(mTelecomManager.getPhoneAccount(PHONE_ACCOUNT_HANDLE_1))
                 .thenReturn(PHONE_ACCOUNT_1);
+        when(mTelecomManager.getPhoneAccount(PHONE_ACCOUNT_HANDLE_2))
+                .thenReturn(PHONE_ACCOUNT_2);
         mController.displayPreference(mPreferenceScreen);
 
-        verify(mPreference).setPhoneAccountHandle(PHONE_ACCOUNT_HANDLE_1);
+        verify(mPreference).setPhoneAccountHandle(PHONE_ACCOUNT_HANDLE_2);
     }
 
     @Test
@@ -128,7 +130,7 @@ public class PhoneRingtonePreferenceControllerTest {
         verify(mPreference).setTitle(mContext.getString(R.string.ringtone_title)
                 + " - " + PHONE_ACCOUNT_HANDLE_DISPLAY_NAME);
     }
-    
+
     @Test
     public void isAvailable_notVoiceCapable_shouldReturnFalse() {
         when(mTelephonyManager.isVoiceCapable()).thenReturn(false);
@@ -137,8 +139,25 @@ public class PhoneRingtonePreferenceControllerTest {
     }
 
     @Test
-    public void isAvailable_VoiceCapable_shouldReturnTrue() {
+    public void isAvailable_notMultiPhoneAccountHandle_shouldReturnFalse() {
         when(mTelephonyManager.isVoiceCapable()).thenReturn(true);
+        when(mTelecomManager.getCallCapablePhoneAccounts(true))
+                .thenReturn(Arrays.asList(PHONE_ACCOUNT_HANDLE_1));
+        when(mTelecomManager.getPhoneAccount(PHONE_ACCOUNT_HANDLE_1))
+                .thenReturn(PHONE_ACCOUNT_1);
+
+        assertThat(mController.isAvailable()).isFalse();
+    }
+
+    @Test
+    public void isAvailable_VoiceCapable_and_MultiPhoneAccountHandle_shouldReturnTrue() {
+        when(mTelephonyManager.isVoiceCapable()).thenReturn(true);
+        when(mTelecomManager.getCallCapablePhoneAccounts(true))
+                .thenReturn(Arrays.asList(PHONE_ACCOUNT_HANDLE_1, PHONE_ACCOUNT_HANDLE_2));
+        when(mTelecomManager.getPhoneAccount(PHONE_ACCOUNT_HANDLE_1))
+                .thenReturn(PHONE_ACCOUNT_1);
+        when(mTelecomManager.getPhoneAccount(PHONE_ACCOUNT_HANDLE_2))
+                .thenReturn(PHONE_ACCOUNT_2);
 
         assertThat(mController.isAvailable()).isTrue();
     }

--- a/tests/uitests/src/com/android/settings/ui/SoundSettingsTest.java
+++ b/tests/uitests/src/com/android/settings/ui/SoundSettingsTest.java
@@ -17,6 +17,7 @@
 package com.android.settings.ui;
 
 import android.content.ContentResolver;
+import android.content.Context;
 import android.os.SystemClock;
 import android.provider.Settings;
 import android.support.test.uiautomator.By;
@@ -25,11 +26,19 @@ import android.support.test.uiautomator.UiObject2;
 import android.support.test.uiautomator.Until;
 import android.system.helpers.SettingsHelper;
 import android.system.helpers.SettingsHelper.SettingsType;
+import android.telecom.PhoneAccount;
+import android.telecom.PhoneAccountHandle;
+import android.telecom.TelecomManager;
+import android.telephony.SubscriptionInfo;
+import android.telephony.SubscriptionManager;
+import android.telephony.TelephonyManager;
 import android.test.InstrumentationTestCase;
 import android.test.suitebuilder.annotation.MediumTest;
 import android.test.suitebuilder.annotation.Suppress;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 public class SoundSettingsTest extends InstrumentationTestCase {
     private static final String PAGE = Settings.ACTION_SOUND_SETTINGS;
@@ -38,7 +47,11 @@ public class SoundSettingsTest extends InstrumentationTestCase {
     private UiDevice mDevice;
     private ContentResolver mResolver;
     private SettingsHelper mHelper;
-
+    private TelecomManager mTelecomManager;
+    private String mRingtoneSettingForPhoneAccountHandle1 = Settings.System.RINGTONE;
+    private String mRingtoneSettingForPhoneAccountHandle2 = Settings.System.RINGTONE;
+    private String mRingtoneSettingTitleForPhoneAccountHandle1 = "Phone ringtone";
+    private String mRingtoneSettingTitleForPhoneAccountHandle2 = "Phone ringtone";
 
     private HashMap ringtoneSounds = new HashMap<String, String>() {{
         put("angler","Dione");
@@ -102,6 +115,9 @@ public class SoundSettingsTest extends InstrumentationTestCase {
         mDevice.setOrientationNatural();
         mResolver = getInstrumentation().getContext().getContentResolver();
         mHelper = new SettingsHelper();
+        mTelecomManager = (TelecomManager) getInstrumentation().getContext()
+                .getSystemService(Context.TELECOM_SERVICE);
+        initRingtoneSetting();
     }
 
     @Override
@@ -183,27 +199,55 @@ public class SoundSettingsTest extends InstrumentationTestCase {
     @MediumTest
     public void testPhoneRingtoneNone() throws Exception {
         launchSoundSettings();
-        mHelper.clickSetting("Phone ringtone");
-        verifyRingtone(new RingtoneSetting("None", "null"),
-                Settings.System.RINGTONE);
+        if (hasMultiPhoneAccountHandle()) {
+            mHelper.clickSetting(mRingtoneSettingTitleForPhoneAccountHandle1);
+            verifyRingtone(new RingtoneSetting("None", "null"),
+                    mRingtoneSettingForPhoneAccountHandle1);
+            mHelper.clickSetting(mRingtoneSettingTitleForPhoneAccountHandle2);
+            verifyRingtone(new RingtoneSetting("None", "null"),
+                    mRingtoneSettingForPhoneAccountHandle2);
+        } else {
+            mHelper.clickSetting(mRingtoneSettingTitleForPhoneAccountHandle1);
+            verifyRingtone(new RingtoneSetting("None", "null"),
+                    mRingtoneSettingForPhoneAccountHandle1);
+        }
     }
 
     @MediumTest
     @Suppress
     public void testPhoneRingtoneHangouts() throws Exception {
         launchSoundSettings();
-        mHelper.clickSetting("Phone ringtone");
-        verifyRingtone(new RingtoneSetting("Hangouts Call", "31"), Settings.System.RINGTONE);
+        if (hasMultiPhoneAccountHandle()) {
+            mHelper.clickSetting(mRingtoneSettingTitleForPhoneAccountHandle1);
+            verifyRingtone(new RingtoneSetting("Hangouts Call", "31"),
+                    mRingtoneSettingForPhoneAccountHandle1);
+            mHelper.clickSetting(mRingtoneSettingTitleForPhoneAccountHandle2);
+            verifyRingtone(new RingtoneSetting("Hangouts Call", "31"),
+                    mRingtoneSettingForPhoneAccountHandle2);
+        } else {
+            mHelper.clickSetting(mRingtoneSettingTitleForPhoneAccountHandle1);
+            verifyRingtone(new RingtoneSetting("Hangouts Call", "31"),
+                    mRingtoneSettingForPhoneAccountHandle1);
+        }
     }
 
     @MediumTest
     public void testPhoneRingtone() throws Exception {
         launchSoundSettings();
-        mHelper.clickSetting("Phone ringtone");
         String ringtone = ringtoneSounds.get(mDevice.getProductName()).toString();
         String ringtoneSettingValue = ringtoneCodes.get(mDevice.getProductName()).toString();
-        verifyRingtone(new RingtoneSetting(ringtone, ringtoneSettingValue),
-                Settings.System.RINGTONE);
+        if (hasMultiPhoneAccountHandle()) {
+            mHelper.clickSetting(mRingtoneSettingTitleForPhoneAccountHandle1);
+            verifyRingtone(new RingtoneSetting(ringtone, ringtoneSettingValue),
+                    mRingtoneSettingForPhoneAccountHandle1);
+            mHelper.clickSetting(mRingtoneSettingTitleForPhoneAccountHandle2);
+            verifyRingtone(new RingtoneSetting(ringtone, ringtoneSettingValue),
+                    mRingtoneSettingForPhoneAccountHandle2);
+        } else {
+            mHelper.clickSetting(mRingtoneSettingTitleForPhoneAccountHandle1);
+            verifyRingtone(new RingtoneSetting(ringtone, ringtoneSettingValue),
+                    mRingtoneSettingForPhoneAccountHandle1);
+        }
     }
 
     @MediumTest
@@ -285,6 +329,63 @@ public class SoundSettingsTest extends InstrumentationTestCase {
         }
     }
 
+    private void initRingtoneSetting() {
+        List<PhoneAccountHandle> accountHandles = getPhoneAccountHandles();
+        if (accountHandles == null || accountHandles.size() == 0) {
+            return;
+        }
+        PhoneAccountHandle phoneAccountHandle1 = accountHandles.get(0);
+        mRingtoneSettingForPhoneAccountHandle1 += "_" + phoneAccountHandle1.getId();
+        if (accountHandles.size() > 1) {
+            PhoneAccountHandle phoneAccountHandle2 = accountHandles.get(1);
+            mRingtoneSettingForPhoneAccountHandle2 += "_" + phoneAccountHandle2.getId();
+
+            CharSequence nameForRingtonePreference1 = getDisplayNameForRingtonePreference(
+                    phoneAccountHandle1);
+            if (nameForRingtonePreference1 != null) {
+                mRingtoneSettingTitleForPhoneAccountHandle1 += " - " + nameForRingtonePreference1;
+            }
+            CharSequence nameForRingtonePreference2 = getDisplayNameForRingtonePreference(
+                    phoneAccountHandle2);
+            if (nameForRingtonePreference2 != null) {
+                mRingtoneSettingTitleForPhoneAccountHandle2 += " - " + nameForRingtonePreference2;
+            }
+        }
+    }
+
+    private List<PhoneAccountHandle> getPhoneAccountHandles() {
+        List<PhoneAccountHandle> subscriptionAccountHandles = new ArrayList<>();
+        List<PhoneAccountHandle> accountHandles = mTelecomManager.getCallCapablePhoneAccounts(true);
+        for (PhoneAccountHandle accountHandle : accountHandles) {
+            PhoneAccount phoneAccount = mTelecomManager.getPhoneAccount(accountHandle);
+            // Emergency phone account also has CAPABILITY_SIM_SUBSCRIPTION, so should exclude it.
+            if (phoneAccount.hasCapabilities(PhoneAccount.CAPABILITY_SIM_SUBSCRIPTION)
+                    && !"E".equals(accountHandle.getId())) {
+                subscriptionAccountHandles.add(accountHandle);
+            }
+        }
+        return subscriptionAccountHandles;
+    }
+
+    private boolean hasMultiPhoneAccountHandle() {
+        return getPhoneAccountHandles().size() > 1;
+    }
+
+    private CharSequence getDisplayNameForRingtonePreference(
+            PhoneAccountHandle phoneAccountHandle) {
+        SubscriptionManager subscriptionManager = (SubscriptionManager) getInstrumentation()
+                .getContext().getSystemService(Context.TELEPHONY_SUBSCRIPTION_SERVICE);
+        TelephonyManager telephonyManager = (TelephonyManager) getInstrumentation()
+                .getContext().getSystemService(Context.TELEPHONY_SERVICE);
+        PhoneAccount phoneAccount = mTelecomManager.getPhoneAccount(phoneAccountHandle);
+        int subId = telephonyManager.getSubIdForPhoneAccount(phoneAccount);
+        SubscriptionInfo subInfo = subscriptionManager.getActiveSubscriptionInfo(subId);
+        if (subInfo != null) {
+            return subInfo.getDisplayName();
+        }
+        return null;
+    }
+    
     private enum ScrollDir {
         UP,
         DOWN,


### PR DESCRIPTION
Phone ringtone setting for Multi SIM device

Support displaying phone ringtone setting for each PhoneAccountHandle.
1. When only insert one SIM, which creates only one PhoneAccountHandle,
ringtone setting should display:
"Phone ringtone"
2. When insert two SIM, which creates two PhoneAccountHandle, ringtone
setting for each SIM should display:
"Phone ringtone - operator name"

The purpose is to distinguish incoming call from each SIM by ringtone.