### PR TITLE
MediaOutputPanel: Handle the case of missing packageName

### DIFF
--- a/src/com/android/settings/panel/MediaOutputPanel.java
+++ b/src/com/android/settings/panel/MediaOutputPanel.java
@@ -41,6 +41,7 @@ import androidx.lifecycle.OnLifecycleEvent;
 import com.android.internal.annotations.VisibleForTesting;
 import com.android.settings.R;
 import com.android.settings.Utils;
+import com.android.settings.media.MediaOutputUtils;
 import com.android.settingslib.media.InfoMediaDevice;
 import com.android.settingslib.media.LocalMediaManager;
 import com.android.settingslib.media.MediaDevice;
@@ -73,6 +74,15 @@ public class MediaOutputPanel implements PanelContent, LocalMediaManager.DeviceC
     private MediaController mMediaController;
 
     public static MediaOutputPanel create(Context context, String packageName) {
+        // Try to get the package name of the active media controller if packageName is null
+        if (packageName == null) {
+            final MediaController mediaController = MediaOutputUtils.getActiveLocalMediaController(
+                    context.getSystemService(MediaSessionManager.class));
+            packageName = (mediaController != null
+                                  && !TextUtils.isEmpty(mediaController.getPackageName()))
+                    ? mediaController.getPackageName()
+                    : "";
+        }
         // Redirect to new media output dialog
         context.sendBroadcast(new Intent()
                 .addFlags(Intent.FLAG_RECEIVER_FOREGROUND)


### PR DESCRIPTION
If packageName is null here it causes an exception at
MediaOutputDialogReceiver. In case of it being null it
should be safe to assume the currently active media
session.

If there is no currently active media session set packageName
to "" instead of null to avoid the previous exception and
launch the media output dialog without details about the
media session.

Change-Id: Ie0e1a3354450c71c511ae7cdba1ce4747d33174e