### PR TITLE
Settings: Whitelist WRITE_DEVICE_CONFIG permission

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -60,6 +60,7 @@
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.READ_DEVICE_CONFIG" />
+    <uses-permission android:name="android.permission.WRITE_DEVICE_CONFIG" />
     <uses-permission android:name="android.permission.STATUS_BAR" />
     <uses-permission android:name="android.permission.MANAGE_USB" />
     <uses-permission android:name="android.permission.MANAGE_DEBUGGING" />


### PR DESCRIPTION
Log:

E DatabaseUtils: Writing exception to parcel
E DatabaseUtils: java.lang.SecurityException: Permission denial: writing to settings requires:android.permission.WRITE_DEVICE_CONFIG
E DatabaseUtils: 	at com.android.providers.settings.SettingsProvider.enforceWritePermission(SettingsProvider.java:2241)
E DatabaseUtils: 	at com.android.providers.settings.SettingsProvider.setAllConfigSettings(SettingsProvider.java:1158)
E DatabaseUtils: 	at com.android.providers.settings.SettingsProvider.call(SettingsProvider.java:471)
E DatabaseUtils: 	at android.content.ContentProvider.call(ContentProvider.java:2464)
E DatabaseUtils: 	at android.content.ContentProvider$Transport.call(ContentProvider.java:512)
E DatabaseUtils: 	at android.content.ContentProviderNative.onTransact(ContentProviderNative.java:295)
E DatabaseUtils: 	at android.os.Binder.execTransactInternal(Binder.java:1179)
E DatabaseUtils: 	at android.os.Binder.execTransact(Binder.java:1143)