### PR TITLE
Google patches

### DIFF
--- a/src/com/android/settings/security/SimLockPreferenceController.java
+++ b/src/com/android/settings/security/SimLockPreferenceController.java
@@ -95,7 +95,8 @@ public class SimLockPreferenceController extends BasePreferenceController {
         for (SubscriptionInfo subInfo : subInfoList) {
             final int simState = mTelephonyManager.getSimState(subInfo.getSimSlotIndex());
             if ((simState != TelephonyManager.SIM_STATE_ABSENT)
-                    && (simState != TelephonyManager.SIM_STATE_UNKNOWN)) {
+                    && (simState != TelephonyManager.SIM_STATE_UNKNOWN)
+                    && (simState != TelephonyManager.SIM_STATE_PERM_DISABLED)) {
                 return true;
             }
         }


### PR DESCRIPTION
For an inserted PUK-blocked SIM card we should not allow
to open lock settings. Add a check for SIM_STATE_PERM_DISABLED
and disable "SIM card lock".

Test: Insert a PUK blocked card and check SIM card lock
Bug: 230370597
Change-Id: I8b468cefe95fb8bd66ab91d6c4569ddb01473fbe