### PR TITLE
Settings: Smart Charging (2/4)

### DIFF
--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -560,4 +560,8 @@
 
     <!-- Whether the given language capitalizes nouns -->
     <bool name="language_capitalizes_nouns">false</bool>
+
+    <!-- Smart Charging -->
+    <bool name="config_supportSmartCharging">false</bool>
+
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -13648,4 +13648,13 @@
     <string name="bluetooth_connect_access_dialog_negative">Don\u2019t connect</string>
     <!-- Strings for Dialog connect button -->
     <string name="bluetooth_connect_access_dialog_positive">Connect</string>
+
+    <!-- Smart charging -->
+    <string name="smart_charging_title">Smart charging</string>
+    <string name="smart_charging_summary">Set maximum charging level</string>
+    <string name="smart_charging_switch_title">Use smart charging</string>
+    <string name="smart_charging_level_title">Stop trigger level</string>
+    <string name="smart_charging_resume_level_title">Start trigger level</string>
+    <string name="smart_charging_footer">Smart Charging allows you to set maximum charging level to extend the lifespan of your battery</string>
+
 </resources>

--- a/res/xml/power_usage_summary.xml
+++ b/res/xml/power_usage_summary.xml
@@ -46,6 +46,12 @@
         android:title="@string/advanced_battery_preference_title"
         settings:searchable="false" />
 
+    <Preference
+        android:fragment="com.android.settings.fuelgauge.smartcharging.SmartChargingSettings"
+        android:key="smart_charging_key"
+        android:summary="@string/smart_charging_summary"
+        android:title="@string/smart_charging_title" />
+
     <com.crdroid.settings.preferences.SystemSettingSwitchPreference
         android:key="battery_24_hrs_stats"
         android:title="@string/advanced_battery_preference_summary_with_hours"

--- a/res/xml/smart_charging.xml
+++ b/res/xml/smart_charging.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2019 RevengeOS
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:settings="http://schemas.android.com/apk/res/com.android.settings"
+    android:key="smart_charging_screen"
+    android:title="@string/smart_charging_title">
+
+    <com.crdroid.settings.preferences.SystemSettingSwitchPreference
+        android:key="smart_charging"
+        android:title="@string/smart_charging_switch_title"
+        android:defaultValue="false" />
+
+    <com.crdroid.settings.preferences.CustomSeekBarPreference
+        android:key="smart_charging_level"
+        android:title="@string/smart_charging_level_title"
+        android:max="99"
+        settings:min="1"
+        settings:units="%"
+        android:defaultValue="80"
+        android:dependency="smart_charging" />
+
+    <com.crdroid.settings.preferences.CustomSeekBarPreference
+        android:key="smart_charging_resume_level"
+        android:title="@string/smart_charging_resume_level_title"
+        android:max="99"
+        settings:min="1"
+        settings:units="%"
+        android:defaultValue="60"
+        android:dependency="smart_charging" />
+
+    <com.android.settingslib.widget.FooterPreference 
+        android:key="footer_preference" 
+        android:title="@string/smart_charging_footer"
+        android:selectable="false" />
+
+</PreferenceScreen>

--- a/src/com/android/settings/fuelgauge/PowerUsageSummary.java
+++ b/src/com/android/settings/fuelgauge/PowerUsageSummary.java
@@ -213,6 +213,12 @@ public class PowerUsageSummary extends PowerUsageBase implements
         }
         mBatteryTipPreferenceController.restoreInstanceState(icicle);
         updateBatteryTipFlag(icicle);
+
+        // Check availability of Smart Charging
+        Preference mSmartCharging = (Preference) findPreference("smart_charging_key");
+        if (!getResources().getBoolean(R.bool.config_supportSmartCharging)) {
+            getPreferenceScreen().removePreference(mSmartCharging);
+        }
     }
 
     @Override

--- a/src/com/android/settings/fuelgauge/smartcharging/SmartChargingSettings.java
+++ b/src/com/android/settings/fuelgauge/smartcharging/SmartChargingSettings.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2019 RevengeOS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.fuelgauge.smartcharging;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.os.UserHandle;
+import android.provider.SearchIndexableResource;
+import android.provider.Settings;
+import androidx.preference.Preference;
+import androidx.preference.Preference.OnPreferenceChangeListener;
+
+import com.android.internal.logging.nano.MetricsProto.MetricsEvent;
+import com.android.settings.R;
+import com.android.settings.dashboard.DashboardFragment;
+import com.android.settings.search.BaseSearchIndexProvider;
+import com.android.settingslib.core.AbstractPreferenceController;
+import com.android.settingslib.core.instrumentation.MetricsFeatureProvider;
+import com.android.settingslib.core.lifecycle.Lifecycle;
+
+import com.crdroid.settings.preferences.CustomSeekBarPreference;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Settings screen for Smart charging
+ */
+public class SmartChargingSettings extends DashboardFragment implements OnPreferenceChangeListener {
+
+    private static final String TAG = "SmartChargingSettings";
+    private static final String KEY_SMART_CHARGING_LEVEL = "smart_charging_level";
+    private static final String KEY_SMART_CHARGING_RESUME_LEVEL = "smart_charging_resume_level";
+
+    private CustomSeekBarPreference mSmartChargingLevel;
+    private CustomSeekBarPreference mSmartChargingResumeLevel;
+
+    private int mSmartChargingLevelDefaultConfig;
+    private int mSmartChargingResumeLevelDefaultConfig;
+
+    @Override
+    public void onCreate(Bundle icicle) {
+        super.onCreate(icicle);
+        mSmartChargingLevelDefaultConfig = getResources().getInteger(
+                com.android.internal.R.integer.config_smartChargingBatteryLevel);
+
+        mSmartChargingResumeLevelDefaultConfig = getResources().getInteger(
+                com.android.internal.R.integer.config_smartChargingBatteryResumeLevel);
+        mSmartChargingLevel = (CustomSeekBarPreference) findPreference(KEY_SMART_CHARGING_LEVEL);
+        int currentLevel = Settings.System.getInt(getContentResolver(),
+            Settings.System.SMART_CHARGING_LEVEL, mSmartChargingLevelDefaultConfig);
+        mSmartChargingLevel.setValue(currentLevel);
+        mSmartChargingLevel.setOnPreferenceChangeListener(this);
+        mSmartChargingResumeLevel = (CustomSeekBarPreference) findPreference(KEY_SMART_CHARGING_RESUME_LEVEL);
+        int currentResumeLevel = Settings.System.getInt(getContentResolver(),
+            Settings.System.SMART_CHARGING_RESUME_LEVEL, mSmartChargingResumeLevelDefaultConfig);
+        if (currentResumeLevel >= currentLevel) currentResumeLevel = currentLevel -1;
+        mSmartChargingResumeLevel.setValue(currentResumeLevel);
+        mSmartChargingResumeLevel.setOnPreferenceChangeListener(this);
+    }
+
+    @Override
+    protected String getLogTag() {
+        return TAG;
+    }
+
+    @Override
+    protected int getPreferenceScreenResId() {
+        return R.xml.smart_charging;
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsEvent.CRDROID_SETTINGS;
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object objValue) {
+        if (preference == mSmartChargingLevel) {
+            int smartChargingLevel = (Integer) objValue;
+            int mChargingResumeLevel = Settings.System.getInt(getContentResolver(),
+                     Settings.System.SMART_CHARGING_RESUME_LEVEL, mSmartChargingResumeLevelDefaultConfig);
+            Settings.System.putInt(getContentResolver(),
+                    Settings.System.SMART_CHARGING_LEVEL, smartChargingLevel);
+            if (smartChargingLevel <= mChargingResumeLevel) {
+                mSmartChargingResumeLevel.setValue(smartChargingLevel - 1);
+                Settings.System.putInt(getContentResolver(),
+                    Settings.System.SMART_CHARGING_RESUME_LEVEL, smartChargingLevel - 1);
+            }
+            return true;
+        } else if (preference == mSmartChargingResumeLevel) {
+            int smartChargingResumeLevel = (Integer) objValue;
+            int mChargingLevel = Settings.System.getInt(getContentResolver(),
+                     Settings.System.SMART_CHARGING_LEVEL, mSmartChargingLevelDefaultConfig);
+               Settings.System.putInt(getContentResolver(),
+                    Settings.System.SMART_CHARGING_RESUME_LEVEL, smartChargingResumeLevel);
+            return true;
+        } else {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Change-Id: Ie82d435125c379c6158908d6e8beb8063f4acd88

Smart Charging: allow user set resume level [2/2]

Change-Id: If730fa6b767fe0736b4e169194921659257ffc7b

* Also add footer explanation

Smart Charging: Make it optional

* Allows a device maintainer to show/hide the Smart Charging pref in Power Settings
* Enabled by default

Change-Id: I0dcbdab57e5cef2e599054f570137078a751d4ac

Smart Charging: Lower the minimum value of charging start

Signed-off-by: spezi77 <spezi7713@gmx.net>
Change-Id: I4e102b83e34dd6d99b56335b5f2a9b173e44af0b