### PR TITLE
Settings: Fix gestures saving parameters

### DIFF
--- a/src/com/android/settings/gestures/GestureNavigationSettingsFragment.java
+++ b/src/com/android/settings/gestures/GestureNavigationSettingsFragment.java
@@ -150,7 +150,6 @@ public class GestureNavigationSettingsFragment extends DashboardFragment {
         pref.setHapticFeedbackMode(SeekBarPreference.HAPTIC_FEEDBACK_MODE_ON_TICKS);
 
         String settingsKey;
-        float initScale = 0;
 
         switch(key) {
             case LEFT_EDGE_SEEKBAR_KEY:
@@ -167,6 +166,8 @@ public class GestureNavigationSettingsFragment extends DashboardFragment {
                 break;
         }
 
+        float[] scales = mBackGestureInsetScales;
+        float initScale = 0;
         if (settingsKey != "") {
             initScale = Settings.Secure.getFloat(
                   getContext().getContentResolver(), settingsKey, 1.0f);
@@ -181,7 +182,7 @@ public class GestureNavigationSettingsFragment extends DashboardFragment {
         mCurrentLefttWidth = (int) (mDefaultBackGestureInset * currentWidthScale);
 
         if (key == GESTURE_BACK_HEIGHT_KEY) {
-            mBackGestureInsetScales = mBackGestureHeightScales;
+            scales = mBackGestureHeightScales;
             initScale = Settings.System.getInt(
                     getContext().getContentResolver(), settingsKey, 0);
         }
@@ -189,8 +190,8 @@ public class GestureNavigationSettingsFragment extends DashboardFragment {
         // Find the closest value to initScale
         float minDistance = Float.MAX_VALUE;
         int minDistanceIndex = -1;
-        for (int i = 0; i < mBackGestureInsetScales.length; i++) {
-            float d = Math.abs(mBackGestureInsetScales[i] - initScale);
+        for (int i = 0; i < scales.length; i++) {
+            float d = Math.abs(scales[i] - initScale);
             if (d < minDistance) {
                 minDistance = d;
                 minDistanceIndex = i;
@@ -208,7 +209,7 @@ public class GestureNavigationSettingsFragment extends DashboardFragment {
                     mCurrentRightWidth = width;
                 }
             } else {
-                final int heightScale = (int) (mBackGestureInsetScales[(int) v]);
+                final int heightScale = (int) (mBackGestureHeightScales[(int) v]);
                 mIndicatorView.setIndicatorHeightScale(heightScale);
                 // dont use updateViewLayout else it will animate
                 mWindowManager.removeView(mIndicatorView);
@@ -222,14 +223,13 @@ public class GestureNavigationSettingsFragment extends DashboardFragment {
         });
 
         pref.setOnPreferenceChangeStopListener((p, v) -> {
-            final float scale = mBackGestureInsetScales[(int) v];
             if (key == GESTURE_BACK_HEIGHT_KEY) {
                 mIndicatorView.setIndicatorWidth(0, false);
                 mIndicatorView.setIndicatorWidth(0, true);
-                Settings.System.putInt(getContext().getContentResolver(), settingsKey, (int) scale);
+                Settings.System.putInt(getContext().getContentResolver(), settingsKey, (int) mBackGestureHeightScales[(int) v]);
             } else {
                 mIndicatorView.setIndicatorWidth(0, key == LEFT_EDGE_SEEKBAR_KEY);
-                Settings.Secure.putFloat(getContext().getContentResolver(), settingsKey, scale);
+                Settings.Secure.putFloat(getContext().getContentResolver(), settingsKey, mBackGestureInsetScales[(int) v]);
             }
             return true;
         });


### PR DESCRIPTION
Currently in our 13.0 branch, going into Settings > System > Gestures, choosing Gesture Navigation, pressing the gear icon for Gesture Nav settings, scrolling down, and changing the "Back" gesture sensitivity essentially disables it. You can't trigger back at all.

RayStef66 pointed out this issue to me & asked if I had the same behavior on enchilada & fajita, and yes I did. They suggested this commit that was in Evolution-X, https://github.com/Evolution-X/packages_apps_Settings/commit/e9f160a39dab53df8a78c3d02f8284df6ab2150e which I cherry-picked & compiled, and now the back gesture is working again even at "Low" sensitivity.

Test: Compiles, now it appears that setting Left & Right side sensitivity to "Low", then interacting with a control near the edge of the screan doesn't result in the drag always being interpreted as initiating a "Back" swipe. It's now much easier to grab the resize handle when trying to crop screenshots that are near the edge of the screen for example, which is typically difficult to do with default sensitivity.