### PR TITLE
13.0 - Navigation Pill thickness customization [2/2]

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -14404,4 +14404,9 @@
     <!-- [CHAR LIMIT=NONE] Hint for QR code process failure -->
     <string name="bt_le_audio_qr_code_is_not_valid_format">QR code isn\u0027t a valid format</string>
 
+    <!-- Gesture navbar radius -->
+    <string name="gesture_navbar_radius_title">Pill radius</string>
+    <string name="thin_label">Thin</string>
+    <string name="thick_label">Thick</string>
+
 </resources>

--- a/res/xml/gesture_navigation_settings.xml
+++ b/res/xml/gesture_navigation_settings.xml
@@ -60,6 +60,14 @@
         android:summary="@string/back_gesture_haptic_summary"
         android:defaultValue="true" />
 
+    <com.android.settings.widget.LabeledSeekBarPreference
+        android:key="gesture_navbar_radius_preference"
+        android:title="@string/gesture_navbar_radius_title"
+        android:max="3"
+        android:selectable="true"
+        settings:textStart="@string/thin_label"
+        settings:textEnd="@string/thick_label" />
+
     <PreferenceCategory
         android:key="assistant_gesture_category"
         android:persistent="false"

--- a/res/xml/gesture_navigation_settings.xml
+++ b/res/xml/gesture_navigation_settings.xml
@@ -63,7 +63,7 @@
     <com.android.settings.widget.LabeledSeekBarPreference
         android:key="gesture_navbar_radius_preference"
         android:title="@string/gesture_navbar_radius_title"
-        android:max="3"
+        android:max="5"
         android:selectable="true"
         settings:textStart="@string/thin_label"
         settings:textEnd="@string/thick_label" />

--- a/src/com/android/settings/gestures/GestureNavigationSettingsFragment.java
+++ b/src/com/android/settings/gestures/GestureNavigationSettingsFragment.java
@@ -55,6 +55,7 @@ public class GestureNavigationSettingsFragment extends DashboardFragment {
     private static final String NAVIGATION_BAR_LENGTH_KEY = "gesture_navbar_length_preference";
     private static final String GESTURE_NAVBAR_LENGTH_KEY = "gesture_navbar_length_preference";
     private static final String GESTURE_BACK_HEIGHT_KEY = "gesture_back_height";
+    private static final String GESTURE_NAVBAR_RADIUS_KEY = "gesture_navbar_radius_preference";
 
     private WindowManager mWindowManager;
     private BackGestureIndicatorView mIndicatorView;
@@ -97,6 +98,7 @@ public class GestureNavigationSettingsFragment extends DashboardFragment {
         initSeekBarPreference(GESTURE_BACK_HEIGHT_KEY);
 
         initGestureNavbarLengthPreference();
+        initGestureBarRadiusPreference();
 
         boolean isTaskbarEnabled = LineageSettings.System.getInt(getContext().getContentResolver(),
                 LineageSettings.System.ENABLE_TASKBAR, isTablet(getContext()) ? 1 : 0) == 1;
@@ -245,6 +247,17 @@ public class GestureNavigationSettingsFragment extends DashboardFragment {
         mGestureNavbarLengthPreference.setOnPreferenceChangeListener((p, v) ->
             Settings.System.putIntForUser(resolver, Settings.System.GESTURE_NAVBAR_LENGTH_MODE,
                 (Integer) v, UserHandle.USER_CURRENT));
+    }
+
+    private void initGestureBarRadiusPreference() {
+        final LabeledSeekBarPreference pref = getPreferenceScreen().
+            findPreference(GESTURE_NAVBAR_RADIUS_KEY);
+        pref.setContinuousUpdates(true);
+        pref.setProgress(Settings.System.getInt(getContext().getContentResolver(),
+            Settings.System.GESTURE_NAVBAR_RADIUS, 0));
+        pref.setOnPreferenceChangeListener((p, v) ->
+            Settings.System.putInt(getContext().getContentResolver(),
+                Settings.System.GESTURE_NAVBAR_RADIUS, (Integer) v));
     }
 
     private static float[] getFloatArray(TypedArray array) {


### PR DESCRIPTION
While I was rooting around in Evolution-X in the Settings repo trying to fix the "Back" gesture at "Low" sensitivity, I found this one for yet another tweak to the navigation pill, allowing us to adjust the thickness (and corresponding radius of the roundrect that it's drawn with).
The first commit only allowed making it thicker, and frankly, I'd like for it to be burning in FEWER pixels, so I added those modifications in second commit.
Original: https://github.com/Evolution-X/packages_apps_Settings/commit/294045ed30dd421936688c8c2acb734cfe400bb8

Tests:
Compiled, additional slider for "Pill radius" now in Settings > System > System Navigation > Gesture Navigation settings, works as expected.