### PR TITLE
BatteryHealth: Handle battery info correctly

### DIFF
--- a/src/com/android/settings/fuelgauge/batteryusage/PowerUsageSummary.java
+++ b/src/com/android/settings/fuelgauge/batteryusage/PowerUsageSummary.java
@@ -342,7 +342,11 @@ public class PowerUsageSummary extends PowerUsageBase implements
 
     private String parseBatterymAhText(String file) {
         try {
-            return Integer.parseInt(readLine(file)) / 1000 + " mAh";
+            if(String.valueOf(Integer.parseInt(readLine(file))).length() == 4) {
+                return Integer.parseInt(readLine(file)) + " mAh";
+            } else {
+                return Integer.parseInt(readLine(file)) / 1000 + " mAh";
+            }
         } catch (IOException ioe) {
             Log.e(TAG, "Cannot read battery capacity from "
                     + file, ioe);


### PR DESCRIPTION
Some devices (like Oneplus 9 series) have batteryinfo nodes[1] which already report value in 4 digits hence further trimming it makes the value single digit 
[1] /sys/class/oplus_chg/battery/battery_fcc

Test: Build and check stats