### PR TITLE
Settings: hide battery info

### DIFF
--- a/res/xml/my_device_info.xml
+++ b/res/xml/my_device_info.xml
@@ -154,12 +154,12 @@
             settings:controller="com.android.settings.deviceinfo.firmwareversion.LineageVersionDetailPreferenceController"/>
 
         <!-- Battery information -->
-        <Preference
+        <!--<Preference
             android:key="battery_info"
             android:order="44"
             android:title="@string/battery_info"
             android:fragment="com.android.settings.deviceinfo.batteryinfo.BatteryInfoFragment"
-            settings:keywords="@string/keywords_battery_info"/>
+            settings:keywords="@string/keywords_battery_info"/>-->
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Page is kinda irrelevant imo
- battery date can't be determined easily
- cycle count can be misleading and reset on clean flash

Fixes https://github.com/crdroidandroid/issue_tracker/issues/304