### PR TITLE
Revert "Update the battery saver scheduler minimum level"

### DIFF
--- a/src/com/android/settings/fuelgauge/batterysaver/BatterySaverScheduleRadioButtonsController.java
+++ b/src/com/android/settings/fuelgauge/batterysaver/BatterySaverScheduleRadioButtonsController.java
@@ -41,7 +41,7 @@ import com.android.settingslib.fuelgauge.BatterySaverUtils;
 public class BatterySaverScheduleRadioButtonsController {
     private static final String TAG = "BatterySaverScheduleRadioButtonsController";
 
-    public static final int TRIGGER_LEVEL_MIN = 20;
+    public static final int TRIGGER_LEVEL_MIN = 10;
 
     private Context mContext;
     private BatterySaverScheduleSeekBarController mSeekBarController;


### PR DESCRIPTION
- that commit was creating issue: value set lower than default(20) was not persisting after reboot. 
- as currently  minimum possible value is 10% so given that we don't need to change code as well so simply reverting that commit is suffice.
This reverts commit b0fe225a17f91cdac8a82a2ff0f25ca19b5bf1bb.