### PR TITLE
 Add BatteryDivider to fuelgauge

### DIFF
--- a/res/values/lineage_config.xml
+++ b/res/values/lineage_config.xml
@@ -49,4 +49,7 @@
 
     <!-- Max network scan search time in seconds -->
     <integer name="config_network_scan_helper_max_search_time_sec">300</integer>
+    
+    <!-- Battery Info: mAh -->
+    <integer name="config_battery_divider" translatable="false">1000</integer>
 </resources>

--- a/src/com/android/settings/fuelgauge/BatteryHeaderPreferenceController.java
+++ b/src/com/android/settings/fuelgauge/BatteryHeaderPreferenceController.java
@@ -45,6 +45,7 @@ public class BatteryHeaderPreferenceController extends BasePreferenceController
     @VisibleForTesting BatteryStatusFeatureProvider mBatteryStatusFeatureProvider;
     @VisibleForTesting UsageProgressBarPreference mBatteryUsageProgressBarPref;
 
+    private int mBatteryDivider;
     private BatteryTip mBatteryTip;
     private final PowerManager mPowerManager;
 
@@ -53,6 +54,8 @@ public class BatteryHeaderPreferenceController extends BasePreferenceController
         mPowerManager = context.getSystemService(PowerManager.class);
         mBatteryStatusFeatureProvider =
                 FeatureFactory.getFeatureFactory().getBatteryStatusFeatureProvider();
+                
+        mBatteryDivider = mContext.getResources().getInteger(R.integer.config_battery_divider);
     }
 
     @Override
@@ -137,7 +140,7 @@ public class BatteryHeaderPreferenceController extends BasePreferenceController
         mBatteryUsageProgressBarPref.setPercent(batteryLevel, BATTERY_MAX_LEVEL);
 
         if (chargeCounterUah > 0) {
-            int chargeCounter = chargeCounterUah / 1_000;
+            int chargeCounter = chargeCounterUah / mBatteryDivider;
             mBatteryUsageProgressBarPref.setTotalSummary(
                     formatBatteryChargeCounterText(chargeCounter));
         }


### PR DESCRIPTION
some devices with prebuilt kernel report, example 4mAh, instead of 4000mAh or whatever current mAh is. add config to let override the divider

device tree example:
https://github.com/kamikaonashi/device_xiaomi_stone/commit/830a87b13941e60a1952c56fde57552fe2622d7f