### PR TITLE
Settings: Assign "top_level_account" category by default

### DIFF
--- a/src/com/android/settings/dashboard/DashboardFragment.java
+++ b/src/com/android/settings/dashboard/DashboardFragment.java
@@ -573,10 +573,13 @@ public abstract class DashboardFragment extends SettingsPreferenceFragment
                         group = screen.findPreference("top_level_account_category");
                     } else if (SECURITY_PRIVACY_INJECTED_KEYS.contains(key)) {
                         group = screen.findPreference("top_level_security_privacy_category");
+                    } else {
+                        group = screen.findPreference("top_level_account_category");
                     }
                     if (group instanceof PreferenceCategory) {
                         ((PreferenceCategory) group).addPreference(pref);
                     } else {
+                        // Should never get here now
                         screen.addPreference(pref);
                     }
                 }


### PR DESCRIPTION
Android 15 introduced new preference fragment category grouping.

Most external Device-specific "Parts" settings implementations don't have the necessary metadata keys to supply it correctly.

Rather than require changes to everyone's Device Extras|Parts|Settings preference manifests, let's have DashboardFragment automatically set group to "top_level_account_category" so that newly added pref fragments with no category or special tag metadata get grouped at the top along with crDroid Settings and Google tiles as the fall-through case.

Specifying other metadata for category or special tile key should continue to work as normal.