### PR TITLE
Fixup UI for Settings categories

### DIFF
--- a/res/xml/top_level_settings_v2.xml
+++ b/res/xml/top_level_settings_v2.xml
@@ -230,6 +230,12 @@
     </PreferenceCategory>
 
     <PreferenceCategory
+        android:order="-1"
+        android:key="top_level_filthy_casuals"
+        android:layout="@layout/settingslib_preference_category_no_title">
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:order="100"
         android:key="top_level_support_category"
         android:layout="@layout/settingslib_preference_category_no_title">

--- a/src/com/android/settings/dashboard/DashboardFragment.java
+++ b/src/com/android/settings/dashboard/DashboardFragment.java
@@ -80,7 +80,7 @@ public abstract class DashboardFragment extends SettingsPreferenceFragment
     private static final List<String> ACCOUNT_INJECTED_KEYS = Arrays.asList(
         "top_level_google",
         "dashboard_tile_pref_com.google.android.gms.backup.component.BackupOrRestoreSettingsActivity",
-        "crdroid_deviceextraspartssettings"
+        "crdroid_device_parts_settings"
     );
 
     private static final List<String> SECURITY_PRIVACY_INJECTED_KEYS = Arrays.asList(

--- a/src/com/android/settings/dashboard/DashboardFragment.java
+++ b/src/com/android/settings/dashboard/DashboardFragment.java
@@ -79,7 +79,8 @@ public abstract class DashboardFragment extends SettingsPreferenceFragment
 
     private static final List<String> ACCOUNT_INJECTED_KEYS = Arrays.asList(
         "top_level_google",
-        "dashboard_tile_pref_com.google.android.gms.backup.component.BackupOrRestoreSettingsActivity"
+        "dashboard_tile_pref_com.google.android.gms.backup.component.BackupOrRestoreSettingsActivity",
+        "crdroid_deviceextraspartssettings"
     );
 
     private static final List<String> SECURITY_PRIVACY_INJECTED_KEYS = Arrays.asList(

--- a/src/com/android/settings/dashboard/DashboardFragment.java
+++ b/src/com/android/settings/dashboard/DashboardFragment.java
@@ -573,10 +573,13 @@ public abstract class DashboardFragment extends SettingsPreferenceFragment
                         group = screen.findPreference("top_level_account_category");
                     } else if (SECURITY_PRIVACY_INJECTED_KEYS.contains(key)) {
                         group = screen.findPreference("top_level_security_privacy_category");
+                    } else {
+                        group = screen.findPreference("top_level_filthy_casuals");
                     }
                     if (group instanceof PreferenceCategory) {
                         ((PreferenceCategory) group).addPreference(pref);
                     } else {
+                        // Should never get here now
                         screen.addPreference(pref);
                     }
                 }


### PR DESCRIPTION
Android 15 introduced new preference fragment category grouping.
Visually, that means all settings tiles *with category information* get a background, which is modified to "attach" to other tiles that are in the same category.

However the fall-through case currently applies *no* category, instead of a "generic" category, so the tile is drawn without a grouping background at all, unlike every other setting tile.

This is ugly, and looks like we're doing something wrong when new top-level settings activity fragments are added as tiles.

Commit 1:
Create a fall-through category and modify logic to group added "uncategorized" settings tiles together, so that they also get a background "group" color blob to be visually consistent with other settings tile category groups.

Commit 2:
Create additional key in ACCOUNT_INJECTED_KEYS array so that maintainers with Device Extras|Parts|Settings can optionally add metadata to their app's activity in AndroidManifest.xml so that DashboardFragment will group device-specific settings activy tiles together at the top in the "top_level_account_category" along with crDroid Settings.

(Otherwise it will show up below System-category settings tiles, but at least it will now have a background, after Commit 1 🥳 )

Example 1: "Device Extras" with metadata key added indicating Extras/Parts/Settings app
![with_metadata_key](https://github.com/user-attachments/assets/ec335a7c-0c6a-4af4-9e6a-f65270504c44)

Example 2: "Device Extras" with no metadata key added to AndroidManifext.xml
![no_metadata_key](https://github.com/user-attachments/assets/abd1816a-ab0b-4b02-b384-060c8f9bf59b)

