### PR TITLE
Added missing strings for Polish language

### DIFF
--- a/res/values-pl/cm_strings.xml
+++ b/res/values-pl/cm_strings.xml
@@ -122,4 +122,8 @@
     <string name="battery_design_capacity_summary">%1$d mAh</string>
     <string name="battery_maximum_capacity">Maksymalna pojemność</string>
     <string name="battery_maximum_capacity_summary">%1$d mAh (%2$d%%)</string>
+    <string name="increasing_ring_volume_option_title">Narastająca głośność dzwonka</string>
+    <string name="increasing_ring_min_volume_title">Głośność początkowa</string>
+    <string name="increasing_ring_ramp_up_time_title">Czas narastania</string>
+
 </resources>


### PR DESCRIPTION
When you compare it with English source file cm_strings.xml (located at "values" folder) you can see that those strings are missing. This also wasn't exposed to Crowdin and finally it lasts untranslated in final build system. Please implement it. Ideally for all languages.