### PR TITLE
 Revert "[Settings] Start SettingsDumpService to dump the db log afte…

### DIFF
--- a/src/com/android/settings/SettingsDumpService.java
+++ b/src/com/android/settings/SettingsDumpService.java
@@ -31,14 +31,11 @@ import android.os.storage.VolumeInfo;
 import android.telephony.SubscriptionInfo;
 import android.telephony.SubscriptionManager;
 import android.telephony.TelephonyManager;
-import android.util.IndentingPrintWriter;
-import android.util.Log;
 
 import androidx.annotation.VisibleForTesting;
 
 import com.android.settings.applications.ProcStatsData;
 import com.android.settings.datausage.lib.DataUsageLib;
-import com.android.settings.network.MobileNetworkRepository;
 import com.android.settingslib.net.DataUsageController;
 
 import org.json.JSONArray;
@@ -50,10 +47,6 @@ import java.io.FileDescriptor;
 import java.io.PrintWriter;
 
 public class SettingsDumpService extends Service {
-
-    public static final String EXTRA_KEY_SHOW_NETWORK_DUMP = "show_network_dump";
-
-    private static final String TAG = "SettingsDumpService";
     @VisibleForTesting
     static final String KEY_SERVICE = "service";
     @VisibleForTesting
@@ -70,16 +63,6 @@ public class SettingsDumpService extends Service {
     static final Intent BROWSER_INTENT =
             new Intent("android.intent.action.VIEW", Uri.parse("http://"));
 
-    private boolean mShouldShowNetworkDump = false;
-
-    @Override
-    public int onStartCommand(Intent intent, int flags, int startId) {
-        if (intent != null) {
-            mShouldShowNetworkDump = intent.getBooleanExtra(EXTRA_KEY_SHOW_NETWORK_DUMP, false);
-        }
-        return Service.START_REDELIVER_INTENT;
-    }
-
     @Override
     public IBinder onBind(Intent intent) {
         return null;
@@ -87,26 +70,18 @@ public class SettingsDumpService extends Service {
 
     @Override
     protected void dump(FileDescriptor fd, PrintWriter writer, String[] args) {
-        IndentingPrintWriter pw = new IndentingPrintWriter(writer, "  ");
-        if (!mShouldShowNetworkDump) {
-            JSONObject dump = new JSONObject();
-            pw.println(TAG + ": ");
-            pw.increaseIndent();
-            try {
-                dump.put(KEY_SERVICE, "Settings State");
-                dump.put(KEY_STORAGE, dumpStorage());
-                dump.put(KEY_DATAUSAGE, dumpDataUsage());
-                dump.put(KEY_MEMORY, dumpMemory());
-                dump.put(KEY_DEFAULT_BROWSER_APP, dumpDefaultBrowser());
-            } catch (Exception e) {
-                Log.w(TAG, "exception in dump: ", e);
-            }
-            pw.println(dump);
-            pw.flush();
-            pw.decreaseIndent();
-        } else {
-            dumpMobileNetworkSettings(pw);
+        JSONObject dump = new JSONObject();
+        try {
+            dump.put(KEY_SERVICE, "Settings State");
+            dump.put(KEY_STORAGE, dumpStorage());
+            dump.put(KEY_DATAUSAGE, dumpDataUsage());
+            dump.put(KEY_MEMORY, dumpMemory());
+            dump.put(KEY_DEFAULT_BROWSER_APP, dumpDefaultBrowser());
+        } catch (Exception e) {
+            e.printStackTrace();
         }
+
+        writer.println(dump);
     }
 
     private JSONObject dumpMemory() throws JSONException {
@@ -193,9 +168,5 @@ public class SettingsDumpService extends Service {
         } else {
             return resolveInfo.activityInfo.packageName;
         }
-    }
-
-    private void dumpMobileNetworkSettings(IndentingPrintWriter writer) {
-        MobileNetworkRepository.getInstance(this).dump(writer);
     }
 }

--- a/src/com/android/settings/network/MobileNetworkRepository.java
+++ b/src/com/android/settings/network/MobileNetworkRepository.java
@@ -32,7 +32,6 @@ import android.telephony.TelephonyManager;
 import android.telephony.UiccPortInfo;
 import android.telephony.UiccSlotInfo;
 import android.util.ArrayMap;
-import android.util.IndentingPrintWriter;
 import android.util.Log;
 
 import androidx.annotation.GuardedBy;
@@ -642,16 +641,5 @@ public class MobileNetworkRepository extends SubscriptionManager.OnSubscriptions
 
         default void onAirplaneModeChanged(boolean enabled) {
         }
-    }
-
-    public void dump(IndentingPrintWriter printwriter) {
-        printwriter.println(TAG + ": ");
-        printwriter.increaseIndent();
-        printwriter.println(" availableSubInfoEntityList= " + mAvailableSubInfoEntityList);
-        printwriter.println(" activeSubInfoEntityList=" + mActiveSubInfoEntityList);
-        printwriter.println(" CacheSubscriptionInfoEntityMap= " + sCacheSubscriptionInfoEntityMap);
-        printwriter.println(" SubscriptionInfoMap= " + mSubscriptionInfoMap);
-        printwriter.flush();
-        printwriter.decreaseIndent();
     }
 }

--- a/src/com/android/settings/network/NetworkDashboardFragment.java
+++ b/src/com/android/settings/network/NetworkDashboardFragment.java
@@ -22,7 +22,6 @@ import android.content.Intent;
 import androidx.annotation.Nullable;
 
 import com.android.settings.R;
-import com.android.settings.SettingsDumpService;
 import com.android.settings.core.OnActivityResultListener;
 import com.android.settings.dashboard.DashboardFragment;
 import com.android.settings.search.BaseSearchIndexProvider;
@@ -88,11 +87,6 @@ public class NetworkDashboardFragment extends DashboardFragment implements
 
         controllers.add(vpnPreferenceController);
         controllers.add(privateDnsPreferenceController);
-
-        // Start SettingsDumpService after the MobileNetworkRepository is created.
-        Intent intent = new Intent(context, SettingsDumpService.class);
-        intent.putExtra(SettingsDumpService.EXTRA_KEY_SHOW_NETWORK_DUMP, true);
-        context.startService(intent);
         return controllers;
     }
 


### PR DESCRIPTION
…r the db is"

 * This is arguably the most marvelous commit I've seen in AOSP, simply The perfection

* Starting off with sending out the intent to 'Start SettingsDumpService after the MobileNetworkRepository is created' - every single time the NetworkDashboardFragment is instantiated (basically every time user opens the network dashboard in settings). Trully a great idea!

* And then most satisfying part - SettingsDumpService's lifecycle never finishes, since it's context is passed to the MobileNetworkRepository for singleton instance creation which then proceeds to holding a reference to that context thus keeping the entire service alive along with the application process, which prevents the static singleton from being garbage collected creating an indirect retention cycle. All that over time grows into a solid memory leak

* SettingsDumpService (as well as MobileNetworkRepository instance, obviously) proceed to dangling until the app process gets eventually killed by the lmkd (which is unlikely to happen but still was observed on several devices running stock ROM) or manually terminated by user, but based on the observation, maximum time of dangling could be perfectly equal to global system uptime

* This still remains left out everywhere all the way up to latest AOSP tags and betas, although some vendors stock ROMs seem to have sorted it out

* Since we don't really care about dumping mobile network info (especially in production builds) - revert is the quickest remedy

This reverts commit d6f3ad9178da5aacbe521d2b2fbfbfc0d93af174.

Change-Id: Ifd7ded6cebd5f247cbdeb88035fdeb21cf060412