### PR TITLE
[REQUIRED AT QPR1] logo: re-center with QPR1 menu styling

### DIFF
--- a/res/drawable/crdroid.xml
+++ b/res/drawable/crdroid.xml
@@ -1,9 +1,9 @@
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="217dp"
-    android:height="145dp"
+    android:height="116dp"
     android:viewportWidth="217"
-    android:viewportHeight="145">
+    android:viewportHeight="116">
 
     <group 
 	android:translateY="-56"


### PR DESCRIPTION
In the about > android version of the settings app, the M3 logo needs adjusted to not have a major gap. This fixes this, and is only required once QPR1 is merged.